### PR TITLE
Initial VM extension implementation with tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ samples/matmult
 test/testbase
 test/testcompiler
 test/testsemver
+VM/test/vmregister
+VM/test/operandstacktest

--- a/VM/BytecodeBuilder.cpp
+++ b/VM/BytecodeBuilder.cpp
@@ -1,0 +1,165 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "Base/BaseExtension.hpp"
+#include "Base/FunctionCompilation.hpp"
+#include "BytecodeBuilder.hpp"
+#include "JB1MethodBuilder.hpp"
+#include "TextWriter.hpp"
+#include "TypeDictionary.hpp"
+#include "VirtualMachineState.hpp"
+#include "VMExtension.hpp"
+
+namespace OMR {
+namespace JitBuilder {
+namespace VM {
+
+BytecodeBuilder::BytecodeBuilder(Base::FunctionCompilation *comp,
+                                 VMExtension *vme,
+                                 int32_t bcIndex,
+                                 int32_t bcLength,
+                                 std::string name,
+                                 Context *context)
+    : Builder(comp, context, name)
+    , _vme(vme)
+    , _bcIndex(bcIndex)
+    , _bcLength(bcLength)
+    , _initialVMState(0)
+    , _vmState(0)
+    , _fallThroughBuilder(0) {
+
+}
+
+BytecodeBuilder *
+BytecodeBuilder::AddFallThroughBuilder(LOCATION, BytecodeBuilder *ftb) {
+    assert(_fallThroughBuilder == 0);
+
+    BytecodeBuilder *b = ftb;
+    b = transferVMState(PASSLOC, b);    // may change what b points at if transition coce is needed
+
+    //if (b != ftb)
+    //    TraceIL("IlBuilder[ %p ]:: fallThrough successor changed to [ %p ]\n", this, b);
+
+    _fallThroughBuilder = b;
+    return b;
+}
+
+BytecodeBuilder *
+BytecodeBuilder::AddSuccessorBuilder(LOCATION, BytecodeBuilder *builder) {
+    builder = transferVMState(PASSLOC, builder);
+    // if the code below changes, make sure to check transferVMState() as it also appears in that function
+    _successorBuilders.push_back(builder);   // must be the bytecode builder that comes back from transferVMState()
+    return builder;
+}
+
+// AddSuccessorBuilders() should be called with a list of pointer to BytecodeBuilder *.
+// Each one of these pointers could be changed by AddSuccessorBuilders() in the case where
+// some operations need to be inserted along the control flow edges to synchronize the
+// vm state from "this" builder to the target BytecodeBuilder. For this reason, the actual
+// control flow edges should be created (i.e. with Goto, IfCmp*, etc.) *after* calling
+// AddSuccessorBuilders, and the target used when creating those flow edges should take
+// into account that AddSuccessorBuilders may change the builder object provided.
+void
+BytecodeBuilder::AddSuccessorBuilders(LOCATION, uint32_t numExits, ...) {
+    va_list exits;
+    va_start(exits, numExits);
+    for (auto e = 0; e < numExits; e++) {
+        BytecodeBuilder **pBuilder = (BytecodeBuilder **) va_arg(exits, BytecodeBuilder **);
+        BytecodeBuilder *builder = *pBuilder;
+        builder = AddSuccessorBuilder(PASSLOC, builder);
+        if (builder != *pBuilder)
+            *pBuilder = builder;
+    }
+    va_end(exits);
+}
+
+void
+BytecodeBuilder::propagateVMState(LOCATION, VirtualMachineState *fromVMState) {
+    _initialVMState = fromVMState->MakeCopy(PASSLOC, this);
+    _vmState = fromVMState->MakeCopy(PASSLOC, this);
+}
+
+// transferVMState needs to be called before the actual transfer operation (Goto, IfCmp,
+// etc.) is created because we may need to insert a builder object along that control
+// flow edge to synchronize the vm state at the target (in the case of a merge point).
+// On return, the object pointed at by the "b" parameter may have changed. The caller
+// should direct control for this edge to whatever the parameter passed to "b" is
+// pointing at on return
+BytecodeBuilder *
+BytecodeBuilder::transferVMState(LOCATION, BytecodeBuilder *b) {
+    assert(_vmState != NULL);
+    if (b->initialVMState()) {
+        // there is already an established vm state at the target builder
+        // so we need to synchronize this builder's vm state with the target builder's vm state
+        // for example, the local variables holding the elements on the operand stack may not match
+        // create an intermediate builder object to do that work
+        // TODO: Compilation needs "Kind"s too
+        BytecodeBuilder *intermediateBuilder = _vme->OrphanBytecodeBuilder(static_cast<Base::FunctionCompilation *>(_comp), b->bcIndex(), b->bcLength(), b->name(), b->context());
+
+        _vmState->MergeInto(PASSLOC, b->initialVMState(), intermediateBuilder);
+
+        // direct control to b from intermediateBuilder, but we have already propagated vm state : use BaseExtension::Goto
+        _vme->baseExt()->Goto(PASSLOC, intermediateBuilder, b);
+        intermediateBuilder->_successorBuilders.push_back(b);
+        return intermediateBuilder; // branches should direct towards intermediateBuilder not original *b
+    } else {
+        b->propagateVMState(PASSLOC, _vmState);
+    }
+    return b;
+}
+
+void
+BytecodeBuilder::writeProperties(TextWriter & w) const {
+    this->Builder::writeProperties(w);
+
+    w.indent() << "[ bcIndex " << bcIndex() << " ]" << w.endl();
+    w.indent() << "[ bcLength " << bcLength() << " ]" << w.endl();
+
+    if (_fallThroughBuilder)
+        w.indent() << "[ fallThroughBuilder " << _fallThroughBuilder << " ]" << w.endl();
+    else
+        w.indent() << "[ fallThroughBuilder NULL ]" << w.endl();
+
+    for (auto it=_successorBuilders.begin(); it != _successorBuilders.end(); it++) {
+        BytecodeBuilder *succ = *it;
+        w.indent() << "[ successorBuilder " << succ << " ]" << w.endl();
+    }
+}
+
+void
+BytecodeBuilder::jbgen(JB1MethodBuilder *j1mb) const {
+    j1mb->createBytecodeBuilder(this, bcIndex(), name());
+}
+
+void
+BytecodeBuilder::jbgenSuccessors(JB1MethodBuilder *j1mb) const {
+    if (_controlReachesEnd && _fallThroughBuilder)
+        j1mb->addFallThroughBuilder(this, _fallThroughBuilder);
+
+    for (auto it = _successorBuilders.begin(); it != _successorBuilders.end(); it++) {
+        BytecodeBuilder *succ = *it;
+        j1mb->addSuccessorBuilder(this, succ);
+    }
+}
+
+} // namespace VM
+} // namespace JitBuilder
+} // namespace OMR

--- a/VM/BytecodeBuilder.hpp
+++ b/VM/BytecodeBuilder.hpp
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+        
+#ifndef BYTECODEBUILDER_INCL
+#define BYTECODEBUILDER_INCL
+
+#include "stdint.h"
+#include "stddef.h"
+#include <list>
+#include "Builder.hpp"
+
+namespace OMR {
+namespace JitBuilder {
+
+class Context;
+class TextWriter;
+class Type;
+class TypeDictionary;
+class Value;
+
+namespace Base { class FunctionCompilation; }
+
+namespace VM {
+
+class VirtualMachineRegister;
+class VirtualMachineState;
+class VMExtension;
+
+class BytecodeBuilder: public Builder {
+    friend VMExtension;
+
+public:
+    BytecodeBuilder(Base::FunctionCompilation *comp, VMExtension *vme, int32_t bcIndex, int32_t bcLength=1, std::string name="", Context *context=NULL);
+    int32_t bcIndex() const { return _bcIndex; }
+    int32_t bcLength() const { return _bcLength; }
+
+    void setVMState(VirtualMachineState *state) { _vmState = state; }
+    VirtualMachineState * initialVMState() const { return _initialVMState; }
+    VirtualMachineState * vmState() const { return _vmState; }
+
+    void propagateVMState(LOCATION, VirtualMachineState *fromState);
+
+    virtual std::string logName() const { return "BytecodeBuilder"; }
+    virtual void writeProperties(TextWriter & w) const;
+
+    virtual void jbgen(JB1MethodBuilder *j1mb) const;
+    virtual void jbgenSuccessors(JB1MethodBuilder *j1mb) const;
+
+protected:
+    // no longer need clients to call these; they are called directly by control flow operations created by VMExtension
+    BytecodeBuilder * AddFallThroughBuilder(LOCATION, BytecodeBuilder *ftb);
+    BytecodeBuilder * AddSuccessorBuilder(LOCATION, BytecodeBuilder *b);
+    void AddSuccessorBuilders(LOCATION, uint32_t numBuilders, ...);
+
+    BytecodeBuilder *transferVMState(LOCATION, BytecodeBuilder *b);
+
+    VMExtension * _vme;
+
+    int32_t _bcIndex;
+    int32_t _bcLength;
+    VirtualMachineState * _initialVMState;
+    VirtualMachineState * _vmState;
+
+    BytecodeBuilder * _fallThroughBuilder;
+    std::list<BytecodeBuilder *> _successorBuilders;
+};
+
+} // VM
+} // JitBuilder
+} // OMR
+
+#endif // BYTECODEBUILDER_INCL

--- a/VM/Makefile
+++ b/VM/Makefile
@@ -1,0 +1,32 @@
+COREDIR=..
+CORE=core
+LIBCORE=lib$(CORE).so
+
+BASEDIR=../Base
+BASE=base
+LIBBASE=lib$(BASE).so
+
+VM=vm
+LIBVM=lib$(VM).so
+
+all: $(LIBVM)
+
+VM_OBJECTS = BytecodeBuilder.o \
+             VMExtension.o \
+             VirtualMachineState.o \
+             VirtualMachineRegister.o \
+             VirtualMachineRegisterInStruct.o \
+             VirtualMachineOperandStack.o
+             #VirtualMachineOperandArray.o
+
+$(LIBVM) : $(VM_OBJECTS)
+	g++ -shared -FPIC -o $(LIBVM) $(VM_OBJECTS) -L$(BASE_DIR) -l$(LIBBASE) -L$(CORE_DIR) -l$(LIBCORE)
+
+#CXXFLAGS=-O2 -I./ -I../ -std=c++0x -fno-rtti -fPIC -Wno-writable-strings -D_XOPEN_SOURCE=0
+CXXFLAGS=-O0 -g -I./ -I../ -std=c++0x -fno-rtti -fPIC -Wno-writable-strings -D_XOPEN_SOURCE=0
+
+.cpp.o:
+	g++ $(CXXFLAGS) -c $<
+
+clean:
+	rm -f $(LIBVM) *.o

--- a/VM/VM.hpp
+++ b/VM/VM.hpp
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *   
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef OMR_JITBUILDER_VM_INCL
+#define OMR_JITBUILDER_VM_INCL
+
+#include "VM/BytecodeBuilder.hpp"
+#include "VM/VirtualMachineOperandStack.hpp"
+#include "VM/VirtualMachineRegister.hpp"
+#include "VM/VirtualMachineRegisterInStruct.hpp"
+#include "VM/VirtualMachineState.hpp"
+#include "VM/VMExtension.hpp"
+
+#endif // defined(OMR_JITBUILDER_VM_INCL)
+

--- a/VM/VMExtension.cpp
+++ b/VM/VMExtension.cpp
@@ -1,0 +1,143 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "Base/BaseExtension.hpp"
+#include "Base/FunctionCompilation.hpp"
+#include "BytecodeBuilder.hpp"
+#include "Compiler.hpp"
+#include "VMExtension.hpp"
+
+namespace OMR {
+namespace JitBuilder {
+namespace VM {
+
+const SemanticVersion VMExtension::version(VMEXT_MAJOR,VMEXT_MINOR,VMEXT_PATCH);
+const std::string VMExtension::NAME("vm");
+
+extern "C" {
+    Extension *create(Compiler *compiler) {
+        return new VMExtension(compiler);
+    }
+}
+
+VMExtension::VMExtension(Compiler *compiler, bool extended, std::string extensionName)
+    : Extension(compiler, (extended ? extensionName : NAME))
+    , CompileFail_BaseExtensionNotLoaded(registerReturnCode("BaseExtensionNotLoaded")) {
+
+    if (compiler->validateExtension("Base")) {
+        CompilationException e(LOC, compiler, CompileFail_BaseExtensionNotLoaded);
+        e.setMessageLine(std::string("VM Extension depends on Base extension to be loaded"))
+         .appendMessageLine(std::string("    Call compiler->loadExtension<Base::BaseExtension>(\"base\") before trying to load VM extension"));
+        throw e;
+    }
+
+    _baseExt = compiler->lookupExtension<Base::BaseExtension>("base");
+}
+
+VMExtension::~VMExtension() {
+}
+
+void
+VMExtension::Goto(LOCATION, BytecodeBuilder *b, BytecodeBuilder *target) {
+    target = b->AddSuccessorBuilder(PASSLOC, target);
+    baseExt()->Goto(PASSLOC, b, target);
+}
+
+void
+VMExtension::IfCmpEqual(LOCATION, BytecodeBuilder *b, BytecodeBuilder *target, Value *left, Value *right) {
+    target = b->AddSuccessorBuilder(PASSLOC, target);
+    baseExt()->IfCmpEqual(PASSLOC, b, target, left, right);
+}
+
+void
+VMExtension::IfCmpEqualZero(LOCATION, BytecodeBuilder *b, BytecodeBuilder *target, Value *condition) {
+    target = b->AddSuccessorBuilder(PASSLOC, target);
+    baseExt()->IfCmpEqualZero(PASSLOC, b, target, condition);
+}
+
+void
+VMExtension::IfCmpLessOrEqual(LOCATION, BytecodeBuilder *b, BytecodeBuilder *target, Value *left, Value *right) {
+    target = b->AddSuccessorBuilder(PASSLOC, target);
+    baseExt()->IfCmpLessOrEqual(PASSLOC, b, target, left, right);
+}
+
+void
+VMExtension::IfCmpLessThan(LOCATION, BytecodeBuilder *b, BytecodeBuilder *target, Value *left, Value *right) {
+    target = b->AddSuccessorBuilder(PASSLOC, target);
+    baseExt()->IfCmpLessThan(PASSLOC, b, target, left, right);
+}
+
+void
+VMExtension::IfCmpGreaterOrEqual(LOCATION, BytecodeBuilder *b, BytecodeBuilder *target, Value *left, Value *right) {
+    target = b->AddSuccessorBuilder(PASSLOC, target);
+    baseExt()->IfCmpGreaterOrEqual(PASSLOC, b, target, left, right);
+}
+
+void
+VMExtension::IfCmpGreaterThan(LOCATION, BytecodeBuilder *b, BytecodeBuilder *target, Value *left, Value *right) {
+    target = b->AddSuccessorBuilder(PASSLOC, target);
+    baseExt()->IfCmpGreaterThan(PASSLOC, b, target, left, right);
+}
+
+void
+VMExtension::IfCmpNotEqual(LOCATION, BytecodeBuilder *b, BytecodeBuilder *target, Value *left, Value *right) {
+    target = b->AddSuccessorBuilder(PASSLOC, target);
+    baseExt()->IfCmpNotEqual(PASSLOC, b, target, left, right);
+}
+
+void
+VMExtension::IfCmpNotEqualZero(LOCATION, BytecodeBuilder *b, BytecodeBuilder *target, Value *condition) {
+    target = b->AddSuccessorBuilder(PASSLOC, target);
+    baseExt()->IfCmpNotEqualZero(PASSLOC, b, target, condition);
+}
+
+void
+VMExtension::IfCmpUnsignedLessOrEqual(LOCATION, BytecodeBuilder *b, BytecodeBuilder *target, Value *left, Value *right) {
+    target = b->AddSuccessorBuilder(PASSLOC, target);
+    baseExt()->IfCmpUnsignedLessOrEqual(PASSLOC, b, target, left, right);
+}
+
+void
+VMExtension::IfCmpUnsignedLessThan(LOCATION, BytecodeBuilder *b, BytecodeBuilder *target, Value *left, Value *right) {
+    target = b->AddSuccessorBuilder(PASSLOC, target);
+    baseExt()->IfCmpUnsignedLessThan(PASSLOC, b, target, left, right);
+}
+
+void
+VMExtension::IfCmpUnsignedGreaterOrEqual(LOCATION, BytecodeBuilder *b, BytecodeBuilder *target, Value *left, Value *right) {
+    target = b->AddSuccessorBuilder(PASSLOC, target);
+    baseExt()->IfCmpUnsignedGreaterOrEqual(PASSLOC, b, target, left, right);
+}
+
+void
+VMExtension::IfCmpUnsignedGreaterThan(LOCATION, BytecodeBuilder *b, BytecodeBuilder *target, Value *left, Value *right) {
+    target = b->AddSuccessorBuilder(PASSLOC, target);
+    baseExt()->IfCmpUnsignedGreaterThan(PASSLOC, b, target, left, right);
+}
+
+BytecodeBuilder *
+VMExtension::OrphanBytecodeBuilder(Base::FunctionCompilation *comp, int32_t bcIndex, int32_t bcLength, std::string name, Context *context) {
+    return new BytecodeBuilder(comp, this, bcIndex, bcLength, name, context);
+}
+
+} // namespace VM
+} // namespace JitBuilder
+} // namespace OMR

--- a/VM/VMExtension.hpp
+++ b/VM/VMExtension.hpp
@@ -1,0 +1,107 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *   
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef VMEXTENSION_INCL
+#define VMEXTENSION_INCL
+
+#include <stdint.h>
+#include <map>
+#include "CreateLoc.hpp"
+#include "Extension.hpp"
+#include "IDs.hpp"
+#include "SemanticVersion.hpp"
+#include "typedefs.hpp"
+
+
+namespace OMR {
+namespace JitBuilder {
+
+class Compilation;
+class Context;
+class Location;
+class Value;
+
+namespace Base { class BaseExtension; }
+
+namespace VM {
+
+class VMExtension : public Extension {
+    friend class VMExtensionChecker;
+
+public:
+    VMExtension(Compiler *compiler, bool extended=false, std::string extensionName="vm");
+    virtual ~VMExtension();
+
+    static const std::string NAME;
+    static const MajorID VMEXT_MAJOR=0;
+    static const MinorID VMEXT_MINOR=1;
+    static const PatchID VMEXT_PATCH=0;
+
+    virtual const SemanticVersion * semver() const {
+        return &version;
+    }
+
+    Base::BaseExtension *baseExt() const { return _baseExt; }
+
+    //
+    // Types
+    //
+
+    //
+    // Actions
+    //
+
+    //
+    // CompilerReturnCodes
+    //
+    const CompilerReturnCode CompileFail_BaseExtensionNotLoaded;
+
+    //
+    // Operations
+    //
+
+    // Pseudo operations
+    void Goto(LOCATION, BytecodeBuilder *b, BytecodeBuilder *target);
+    void IfCmpEqual(LOCATION, BytecodeBuilder *b, BytecodeBuilder *target, Value *left, Value *right);
+    void IfCmpEqualZero(LOCATION, BytecodeBuilder *b, BytecodeBuilder *target, Value *condition);
+    void IfCmpLessOrEqual(LOCATION, BytecodeBuilder *b, BytecodeBuilder *target, Value *left, Value *right);
+    void IfCmpLessThan(LOCATION, BytecodeBuilder *b, BytecodeBuilder *target, Value *left, Value *right);
+    void IfCmpGreaterOrEqual(LOCATION, BytecodeBuilder *b, BytecodeBuilder *target, Value *left, Value *right);
+    void IfCmpGreaterThan(LOCATION, BytecodeBuilder *b, BytecodeBuilder *target, Value *left, Value *right);
+    void IfCmpNotEqual(LOCATION, BytecodeBuilder *b, BytecodeBuilder *target, Value *left, Value *right);
+    void IfCmpNotEqualZero(LOCATION, BytecodeBuilder *b, BytecodeBuilder *target, Value *condition);
+    void IfCmpUnsignedLessOrEqual(LOCATION, BytecodeBuilder *b, BytecodeBuilder *target, Value *left, Value *right);
+    void IfCmpUnsignedLessThan(LOCATION, BytecodeBuilder *b, BytecodeBuilder *target, Value *left, Value *right);
+    void IfCmpUnsignedGreaterOrEqual(LOCATION, BytecodeBuilder *b, BytecodeBuilder *target, Value *left, Value *right);
+    void IfCmpUnsignedGreaterThan(LOCATION, BytecodeBuilder *b, BytecodeBuilder *target, Value *left, Value *right);
+    BytecodeBuilder *OrphanBytecodeBuilder(Base::FunctionCompilation *comp, int32_t bcIndex, int32_t bcLength=1, std::string name="", Context *context=NULL);
+
+protected:
+    static const SemanticVersion version;
+    Base::BaseExtension *_baseExt;
+};
+
+} // namespace VM
+} // namespace JitBuilder
+} // namespace OMR
+
+#endif // defined(VMEXTENSION_INCL)
+

--- a/VM/VirtualMachineOperandStack.cpp
+++ b/VM/VirtualMachineOperandStack.cpp
@@ -1,0 +1,235 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include <cstring>
+#include "Base/BaseExtension.hpp"
+#include "Base/BaseSymbols.hpp"
+#include "Base/BaseTypes.hpp"
+#include "Base/Function.hpp"
+#include "Value.hpp"
+#include "VirtualMachineOperandStack.hpp"
+#include "VirtualMachineRegister.hpp"
+#include "VMExtension.hpp"
+
+namespace OMR {
+namespace JitBuilder {
+namespace VM {
+
+StateKind VirtualMachineOperandStack::STATEKIND = VirtualMachineState::assignStateKind(AnyStateKind, "VirtualMachineOperandStack");
+
+VirtualMachineOperandStack::VirtualMachineOperandStack(LOCATION,
+                                                       VMExtension *vme,
+                                                       Base::Function *func,
+                                                       int32_t sizeHint,
+                                                       VirtualMachineRegister *stackTopRegister,
+                                                       const Type *elementType,
+                                                       bool growsUp,
+                                                       int32_t stackInitialOffset)
+    : VirtualMachineState(PASSLOC, vme, STATEKIND)
+    , _func(func)
+    , _stackTopRegister(stackTopRegister)
+    , _elementType(elementType)
+    , _stackOffset(stackInitialOffset)
+    , _stackMax(sizeHint)
+    , _stackTop(-1)
+    , _pushAmount(growsUp ? +1 : -1) {
+
+    init(PASSLOC);
+}
+
+VirtualMachineOperandStack::VirtualMachineOperandStack(LOCATION, VirtualMachineOperandStack *other)
+    : VirtualMachineState(PASSLOC, other->_vme, STATEKIND)
+    , _func(other->_func)
+    , _stackTopRegister(other->_stackTopRegister)
+    , _elementType(other->_elementType)
+    , _stackOffset(other->_stackOffset)
+    , _stackMax(other->_stackMax)
+    , _stackTop(other->_stackTop)
+    , _pushAmount(other->_pushAmount)
+    , _stackBaseLocal(other->_stackBaseLocal) {
+
+    _stack = new Value *[_stackMax];
+    int32_t numBytes = _stackMax * sizeof(Value *);
+    memcpy(_stack, other->_stack, numBytes);
+}
+
+
+// commits the simulated operand stack of values to the virtual machine state
+// the given builder object is where the operations to commit the state will be inserted
+// the top of the stack is assumed to be managed independently, most likely
+//    as a VirtualMachineRegister or a VirtualMachineRegisterInStruct
+void
+VirtualMachineOperandStack::Commit(LOCATION, Builder *b) {
+    Base::BaseExtension *base = _vme->baseExt();
+
+    Value *stack = base->Load(PASSLOC, b, _stackBaseLocal);
+
+    // Adjust the vm _stackTopRegister by number of elements that have been pushed onto the stack.
+    // _stackTop is -1 at 0 pushes, 0 for 1 push, so # of elements to adjust by is _stackTop+1
+    _stackTopRegister->Store(PASSLOC, b, stack);
+    _stackTopRegister->Adjust(PASSLOC, b, (_stackTop+1)*_pushAmount);
+
+    for (int32_t i = _stackTop;i >= 0;i--) {
+        Value *element = Pick(_stackTop - i);
+        base->StoreArray(PASSLOC, b, stack, i - _stackOffset, element);
+    }
+}
+
+void
+VirtualMachineOperandStack::Reload(LOCATION, Builder* b) {
+    Base::BaseExtension *base = _vme->baseExt();
+    Value *stack = base->Load(PASSLOC, b, _stackBaseLocal);
+    // reload the elements back into the simulated operand stack
+    // If the # of stack element has changed, the user should adjust the # of elements
+    // using Drop beforehand to add/delete stack elements.
+    for (int32_t i = _stackTop; i >= 0; i--) {
+        _stack[i] = base->LoadArray(PASSLOC, b, stack, i - _stackOffset);
+    }
+}
+
+// Allocate a new operand stack and copy everything in this state
+// If VirtualMachineOperandStack is subclassed, this function *must* also be implemented in the subclass!
+VirtualMachineState *
+VirtualMachineOperandStack::MakeCopy(LOCATION, Builder *b) {
+    return new VirtualMachineOperandStack(PASSLOC, this);
+}
+
+void
+VirtualMachineOperandStack::MergeInto(LOCATION, VirtualMachineState *o, Builder* b) {
+    assert(o->isKind<VirtualMachineOperandStack>());
+    Base::BaseExtension *base = _vme->baseExt();
+    VirtualMachineOperandStack *other = o->refine<VirtualMachineOperandStack>();
+    assert(_stackTop == other->_stackTop);
+    for (int32_t i=_stackTop;i >= 0;i--) {
+        // only need to do something if the two entries aren't already the same
+        if (other->_stack[i] != _stack[i]) {
+            // what if types don't match? could use ConvertTo, but seems...arbitrary
+            // nobody *should* design bytecode set where corresponding elements of stacks from
+            // two incoming control flow edges can have different primitive types. objects, sure
+            // but not primitive types (even different types of objects should have same primitive
+            // type: Address. Expecting to be disappointed here some day...
+            assert(_stack[i]->type() == other->_stack[i]->type()); // "invalid stack merge: primitive type mismatch at same depth stack elements");
+            base->MergeDef(PASSLOC, b, other->_stack[i], _stack[i]);
+        }
+    }
+}
+
+//
+// VirtualMachineOperandStack API
+//
+
+void
+VirtualMachineOperandStack::Drop(int32_t depth) {
+    assert(_stackTop >= depth-1);
+    _stackTop-=depth;
+}
+
+void
+VirtualMachineOperandStack::Dup() {
+    assert(_stackTop >= 0);
+    Value *top = _stack[_stackTop];
+    Push(top);
+}
+
+Value *
+VirtualMachineOperandStack::Pick(int32_t depth) {
+    assert(_stackTop >= depth);
+    return _stack[_stackTop - depth];
+}
+
+Value *
+VirtualMachineOperandStack::Pop() {
+    assert(_stackTop >= 0);
+    return _stack[_stackTop--];
+}
+
+void
+VirtualMachineOperandStack::Push(Value *value) {
+    assert(value);
+    checkSizeAndGrowIfNeeded();
+    _stack[++_stackTop] = value;
+}
+
+Value *
+VirtualMachineOperandStack::Top() {
+    assert(_stackTop >= 0);
+    return _stack[_stackTop];
+}
+
+// Update the OperandStack_base and _stackTopRegister after the Virtual Machine moves the stack.
+// This call will normally be followed by a call to Reload if any of the stack values changed in the move
+void
+VirtualMachineOperandStack::UpdateStack(LOCATION, Builder *b, Value *stack) {
+    Base::BaseExtension *base = _vme->baseExt();
+    base->Store(PASSLOC, b, _stackBaseLocal, stack);
+}
+
+void
+VirtualMachineOperandStack::checkSizeAndGrowIfNeeded() {
+    if (_stackTop == _stackMax - 1)
+        grow();
+}
+
+void
+VirtualMachineOperandStack::grow(int32_t growAmount) {
+    if (growAmount == 0)
+        growAmount = (_stackMax >> 1);
+
+    // if _stackMax == 1, growAmount would still be zero, so bump to 1
+    if (growAmount == 0)
+        growAmount = 1;
+
+    int32_t newMax = _stackMax + growAmount;
+    Value ** newStack = new Value *[newMax];
+
+    int32_t newBytes = newMax * sizeof(Value *);
+    memset(newStack, 0, newBytes);
+
+    int32_t numBytes = _stackMax * sizeof(Value *);
+    memcpy(newStack, _stack, numBytes);
+
+    _stack = newStack;
+    _stackMax = newMax;
+}
+
+void
+VirtualMachineOperandStack::init(LOCATION) {
+    _stack = new Value *[_stackMax];
+
+    int32_t numBytes = _stackMax * sizeof(Value *);
+    memset(_stack, 0, numBytes);
+
+    Base::BaseExtension *base = _vme->baseExt();
+
+    // Create a unique local symbol to hold this OperandStack's base
+    std::string name("VMOS_StackBase_");
+    name.append(std::to_string(_id));
+    _stackBaseLocal = _func->DefineLocal(name, base->PointerTo(LOC, _func->comp(), _elementType));
+
+    // store current operand stack pointer base address so we can use it whenever we need
+    // to recreate the stack as the interpreter would have
+    Builder *b = _func->builderEntry();
+    base->Store(PASSLOC, b, _stackBaseLocal, _stackTopRegister->Load(PASSLOC, b));
+}
+
+} // namespace VM
+} // namespace JitBuilder
+} // namespace OMR

--- a/VM/VirtualMachineOperandStack.hpp
+++ b/VM/VirtualMachineOperandStack.hpp
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+        
+#ifndef VIRTUALMACHINEOPERANDSTACK_INCL
+#define VIRTUALMACHINEOPERANDSTACK_INCL
+
+#include "stdint.h"
+#include "stddef.h"
+#include "VirtualMachineState.hpp"
+
+namespace OMR {
+namespace JitBuilder {
+
+class Builder;
+class Type;
+class Value;
+
+namespace Base { class BytecodeBuilder; }
+namespace Base { class Function; }
+namespace Base { class LocalSymbol; }
+
+namespace VM {
+
+class VirtualMachineRegister;
+
+class VirtualMachineOperandStack: public VirtualMachineState {
+public:
+    static StateKind STATEKIND;
+
+    VirtualMachineOperandStack(LOCATION, VMExtension *vme, Base::Function * func, int32_t sizeHint, VirtualMachineRegister * stackTopRegister, const Type *elementType, bool growsUp=true, int32_t stackInitialOffset=-1);
+    VirtualMachineOperandStack(LOCATION, VirtualMachineOperandStack * other);
+
+    virtual void Commit(LOCATION, Builder * b);
+    virtual void Reload(LOCATION, Builder * b);
+    virtual VirtualMachineState * MakeCopy(LOCATION, Builder *b);
+    virtual void MergeInto(LOCATION, VirtualMachineState * vmState, Builder * b);
+
+    void Drop(int32_t depth);
+    void Dup();
+    Value * Pick(int32_t depth);
+    Value * Pop();
+    void Push(Value * value);
+    Value * Top();
+    void UpdateStack(LOCATION, Builder * b, Value * array);
+
+protected:
+    void init(LOCATION);
+    void checkSizeAndGrowIfNeeded();
+    void grow(int32_t growAmount=0);
+
+    Base::Function * _func;
+    VirtualMachineRegister * _stackTopRegister;
+    const Type * _elementType;
+    bool _growsUp;
+
+    int32_t _stackOffset;
+    int32_t _stackMax;
+    int32_t _stackTop;
+    Base::LocalSymbol *_stackBaseLocal;
+    int32_t _pushAmount;
+    Value ** _stack;
+};
+
+} // namespace VM
+} // namespace JitBuilder
+} // namespace OMR
+
+#endif // VIRTUALMACHINEOPERANDSTACK_INCL

--- a/VM/VirtualMachineRegister.cpp
+++ b/VM/VirtualMachineRegister.cpp
@@ -1,0 +1,161 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "Base/BaseExtension.hpp"
+#include "Base/BaseSymbols.hpp"
+#include "Base/BaseTypes.hpp"
+#include "Base/Function.hpp"
+#include "Builder.hpp"
+#include "Value.hpp"
+#include "VirtualMachineRegister.hpp"
+#include "VMExtension.hpp"
+
+namespace OMR {
+namespace JitBuilder {
+namespace VM {
+
+StateKind VirtualMachineRegister::STATEKIND = VirtualMachineState::assignStateKind(AnyStateKind, "VirtualMachineRegister");
+
+VirtualMachineRegister::VirtualMachineRegister(LOCATION,
+                                               VMExtension *vme,
+                                               std::string name,
+                                               Base::Function *func,
+                                               Value * addressOfRegister,
+                                               bool doReload)
+    : VirtualMachineState(PASSLOC, vme, STATEKIND)
+    , _name(name)
+    , _func(func)
+    , _addressOfRegister(addressOfRegister)
+    , _pRegisterType(addressOfRegister->type()->refine<Base::PointerType>()) {
+
+    // assert that addressOfRegister's type is PointerType
+    const Type *regBaseType = _pRegisterType->baseType();
+    _integerTypeForAdjustments = regBaseType;
+    if (regBaseType->isKind<Base::PointerType>()) {
+        _integerTypeForAdjustments = _vme->baseExt()->Word;
+        const Type *baseType = regBaseType->refine<Base::PointerType>()->baseType();
+        _adjustByStep = baseType->size();
+        _isAdjustable = true;
+    } else {
+        _adjustByStep = 0;
+        _isAdjustable = false;
+    }
+    _local = func->DefineLocal(name, regBaseType);
+    if (doReload) {
+        for (auto e=0;e < func->numEntryPoints();e++)
+            Reload(PASSLOC, func->builderEntry(e));
+    }
+}
+
+VirtualMachineRegister::VirtualMachineRegister(LOCATION,
+                                               VMExtension *vme,
+                                               std::string name,
+                                               Base::Function * func,
+                                               StateKind kind)
+        : VirtualMachineState(PASSLOC, vme, kind)
+        , _name(name)
+        , _func(func)
+        , _addressOfRegister(0)
+        , _pRegisterType(NULL) {
+
+    }
+
+//
+// VirtualMachineState API
+//
+
+void
+VirtualMachineRegister::Commit(LOCATION, Builder *b) {
+    Base::BaseExtension *base = _vme->baseExt();
+    Value *oldValue = base->Load(PASSLOC, b, _local);
+    base->StoreAt(PASSLOC, b, _addressOfRegister, oldValue);
+}
+
+VirtualMachineState *
+VirtualMachineRegister::MakeCopy(LOCATION, Builder *b) {
+    return new VirtualMachineRegister(PASSLOC, _vme, _name, _func, _addressOfRegister, false);
+}
+
+void
+VirtualMachineRegister::Reload(LOCATION, Builder *b) {
+    Base::BaseExtension *base = _vme->baseExt();
+    Value *value = base->LoadAt(PASSLOC, b, _addressOfRegister);
+    base->Store(PASSLOC, b, _local, value);
+}
+
+//
+// VirtualMachineRegister API
+//
+
+/**
+ * @brief used in the compiled method to add to the (simulated) register's value
+ * @param b the builder where the operation will be placed to add to the simulated value
+ * @param amount the TR::IlValue that should be added to the simulated value, after multiplication by _adjustByStep
+ * Adjust() is really a convenience function for the common operation of adding a value to the register. More
+ * complicated operations (e.g. multiplying the value) can be built using Load() and Store() if needed.
+ */
+void
+VirtualMachineRegister::Adjust(LOCATION, Builder *b, Value *amount) {
+    Base::BaseExtension *base = _vme->baseExt();
+    Value *oldValue = base->Load(PASSLOC, b, _local);
+    Value *newValue = base->IndexAt(PASSLOC, b, oldValue, amount);
+    base->Store(PASSLOC, b, _local, newValue);
+}
+
+/**
+ * @brief used in the compiled method to add to the (simulated) register's value
+ * @param b the builder where the operation will be placed to add to the simulated value
+ * @param amount the constant value that should be added to the simulated value, after multiplication by _adjustByStep
+ * Adjust() is really a convenience function for the common operation of adding a value to the register. More
+ * complicated operations (e.g. multiplying the value) can be built using Load() and Store() if needed.
+ */
+void
+VirtualMachineRegister::Adjust(LOCATION, Builder *b, size_t amount) {
+    Base::BaseExtension *base = _vme->baseExt();
+    Literal *amountLiteral = base->Word->literal(PASSLOC, b->comp(), reinterpret_cast<LiteralBytes *>(&amount));
+    Value *amountValue = base->ConvertTo(LOC, b, _integerTypeForAdjustments, base->Const(PASSLOC, b, amountLiteral));
+    Adjust(PASSLOC, b, amountValue);
+}
+
+/**
+ * @brief used in the compiled method to load the (simulated) register's value
+ * @param b the builder where the operation will be placed to load the simulated value
+ * @returns TR:IlValue * for the loaded simulated register value
+ */
+Value *
+VirtualMachineRegister::Load(LOCATION, Builder *b) {
+    Base::BaseExtension *base = _vme->baseExt();
+    return base->Load(PASSLOC, b, _local);
+}
+
+/**
+ * @brief used in the compiled method to store to the (simulated) register's value
+ * @param b the builder where the operation will be placed to store to the simulated value
+ */
+void
+VirtualMachineRegister::Store(LOCATION, Builder *b, Value *value) {
+    Base::BaseExtension *base = _vme->baseExt();
+    base->Store(PASSLOC, b, _local, value);
+}
+
+} // namespace VM
+} // namespace JitBuilder
+} // namespace OMR

--- a/VM/VirtualMachineRegister.hpp
+++ b/VM/VirtualMachineRegister.hpp
@@ -1,0 +1,137 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+        
+#ifndef VIRTUALMACHINEREGISTER_INCL
+#define VIRTUALMACHINEREGISTER_INCL
+
+#include "stddef.h"
+#include "stdint.h"
+#include "VirtualMachineState.hpp"
+
+namespace OMR {
+namespace JitBuilder {
+
+namespace Base { class LocalSymbol; }
+namespace Base { class PointerType; }
+class Type;
+class Value;
+
+namespace VM {
+
+// forward declarations for all API classes
+class BytecodeBuilder;
+class VMExtension;
+
+/**
+ * @brief simulate virtual machine state variable via an address
+ *
+ * VirtualMachineRegister can be used to represent values in the virtual machine
+ * at any address. The value does not need to be a virtual machine register, but
+ * often it is the registers of the virtual machine that are candidates for
+ * VirtualMachineRegister. An alternative is VirtualMachineRegisterInStruct,
+ * which may be more convenient if the virtual machine value is stored in a
+ * structure that the compiled method has easy access to (for example, if the
+ * base address of the struct is a parameter of every compiled method such as
+ * a "thread" structure or a "frame" structure).
+ *
+ * The simulated register value is simply stored in a single local variable in the
+ * native stack frame, which gives the compiler visibility to all changes to the
+ * register (and enables dataflow optimization / simplification). Because there is
+ * just a single local variable, the CopyState() and MergeInto() functions do not
+ * need to do anything (the value can accessible from that variable at all program
+ * locations). The Commit() and Reload() functions simply move the value back and
+ * forth between the local variable and the address of the actual virtual machine
+ * state variable.
+ *
+ * VirtualMachineRegister provides four additional functions:
+ * Adjust() adds the given Value to the "simualted" value of the register (two
+ * versions: one adjusts by a Value and the other by a constant amount)
+ * Load() will load the *simulated* value of the register for use in the builder "b"
+ * Store() will store the provided "value" into the *simulated* register by
+ * appending to the builder "b"
+ */
+
+class VirtualMachineRegister : public VirtualMachineState {
+public:
+    static StateKind STATEKIND;
+
+   /**
+    * @brief public constructor used to create a virtual machine state variable
+    * @param vme a pointer to the active VM extension
+    * @param name a string containing the register's name
+    * @param func the function being compiled
+    * @param addressOfRegister is the address of the actual register
+    * @param doReload whether local register should be Reloaded (default true, MakeCopy will pass false)
+    */
+    VirtualMachineRegister(LOCATION, VMExtension *vme, std::string name, Base::Function *func, Value * addressOfRegister, bool doReload=true);
+
+    // virtualmachinestate api
+
+    /**
+     * @brief write the simulated register value to the virtual machine
+     * @param b the builder where the operation will be placed to store the virtual machine value
+     */
+    virtual void Commit(LOCATION, Builder * b);
+
+    virtual VirtualMachineState * MakeCopy(LOCATION, Builder *b);
+
+    /**
+     * @brief since the same local variable is used in all states, nothing is needed to merge one state into another
+     * @param vmState 
+     * @param b 
+     */
+    virtual void MergeInto(LOCATION, VirtualMachineState * vmState, Builder * b) { }
+
+    /**
+     * @brief transfer the current virtual machine register value to the simulated local variable
+     * @param b the builder where the operation will be placed to load the virtual machine value
+     */
+    virtual void Reload(LOCATION, Builder * b);
+
+    // virtualmachineregister api
+    void Adjust(LOCATION, Builder * b, size_t amount);
+    void Adjust(LOCATION, Builder * b, Value * amount);
+    Value * Load(LOCATION, Builder * b);
+    void Store(LOCATION, Builder * b, Value * value);
+
+protected:
+    /**
+     * @brief constructor can be used by subclasses to initialize just the LOCATION, local, and override kind
+     * @param vme the VM extension to use
+     * @param func the function being compiled
+     */
+    VirtualMachineRegister(LOCATION, VMExtension *vme, std::string name, Base::Function * func, StateKind kind=STATEKIND);
+
+    std::string _name;
+    Base::Function *_func;
+    Base::LocalSymbol * _local;
+    uint32_t _adjustByStep;
+    Value * _addressOfRegister;
+    const Base::PointerType *_pRegisterType;
+    const Type *_integerTypeForAdjustments;
+    bool _isAdjustable;
+};
+
+} // VM
+} // JitBuilder
+} // OMR
+
+#endif // !defined(VIRTUALMACHINEREGISTER_INCL)

--- a/VM/VirtualMachineRegisterInStruct.cpp
+++ b/VM/VirtualMachineRegisterInStruct.cpp
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+
+#include "Base/BaseExtension.hpp"
+#include "Base/BaseSymbols.hpp"
+#include "Base/BaseTypes.hpp"
+#include "Base/Function.hpp"
+#include "VirtualMachineRegisterInStruct.hpp"
+#include "VMExtension.hpp"
+
+
+namespace OMR {
+namespace JitBuilder {
+namespace VM {
+
+StateKind VirtualMachineRegisterInStruct::STATEKIND = VirtualMachineState::assignStateKind(VirtualMachineRegister::STATEKIND, "VirtualMachineRegisterInStruct");
+
+VirtualMachineRegisterInStruct::VirtualMachineRegisterInStruct(LOCATION,
+                                                               VMExtension *vme,
+                                                               std::string name,
+                                                               Base::Function *func,
+                                                               const Base::FieldType * fieldType,
+                                                               Base::LocalSymbol * localHoldingStructAddress,
+                                                               bool doReload)
+    : VirtualMachineRegister(PASSLOC, vme, name, func, STATEKIND)
+    , _localHoldingStructAddress(localHoldingStructAddress)
+    , _fieldType(fieldType) {
+
+    const Type *regBaseType = fieldType->type();
+    _integerTypeForAdjustments = regBaseType;
+    if (regBaseType->isKind<Base::PointerType>()) {
+        _integerTypeForAdjustments = _vme->baseExt()->Word;
+        const Type *baseType = regBaseType->refine<Base::PointerType>()->baseType();
+        _adjustByStep = baseType->size();
+        _isAdjustable = true;
+    } else {
+        _adjustByStep = 0;
+        _isAdjustable = false;
+    }
+
+    _local = func->DefineLocal(name, regBaseType);
+    if (doReload) {
+        for (auto e=0;e < func->numEntryPoints();e++)
+            Reload(PASSLOC, func->builderEntry(e));
+    }
+}
+
+void
+VirtualMachineRegisterInStruct::Commit(LOCATION, Builder *b) {
+    Base::BaseExtension *base = _vme->baseExt();
+    Value *structBase = base->Load(PASSLOC, b, _localHoldingStructAddress);
+    Value *registerValue = base->Load(PASSLOC, b, _local);
+    base->StoreFieldAt(PASSLOC, b, _fieldType, structBase, registerValue);
+}
+
+VirtualMachineState *
+VirtualMachineRegisterInStruct::MakeCopy(LOCATION, Builder *b) {
+    return new  VirtualMachineRegisterInStruct(PASSLOC, _vme, _name, _func, _fieldType, _localHoldingStructAddress, false);
+}
+
+void
+VirtualMachineRegisterInStruct::Reload(LOCATION, Builder *b) {
+    Base::BaseExtension *base = _vme->baseExt();
+    Value *structBase = base->Load(PASSLOC, b, _localHoldingStructAddress);
+    Value *registerValue = base->LoadFieldAt(PASSLOC, b, _fieldType, structBase);
+    base->Store(PASSLOC, b, _local, registerValue);
+}
+
+} // namespace VM
+} // namespace JitBuilder
+} // namespace OMR

--- a/VM/VirtualMachineRegisterInStruct.hpp
+++ b/VM/VirtualMachineRegisterInStruct.hpp
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+        
+#ifndef VIRTUALMACHINEREGISTERINSTRUCT_INCL
+#define VIRTUALMACHINEREGISTERINSTRUCT_INCL
+
+#include "VirtualMachineRegister.hpp"
+
+namespace OMR {
+namespace JitBuilder {
+
+class Builder;
+namespace Base { class FieldType; }
+namespace Base { class LocalSymbol; }
+
+namespace VM {
+
+class VMExtension;
+
+/**
+ * @brief used to represent virtual machine variables that are maintained in a structure stored in a local variable, such as a thread or frame object passed as a parameter to the method
+ *
+ * The value does not need to be a virtual machine register, but often it is the registers
+ * of the virtual machine that are candidates for VirtualMachineRegisterInStruct. An
+ * alternative is VirtualMachineRegister, which can be more convenient if the virtual
+ * machine value is stored in a more arbitrary place or in a structure that isn't readily
+ * accessible inside the compiled method.
+ * VirtualMachineRegisterInStruct is a subclass of VirtualMachineRegister
+ *
+ * The simulated register value is simply stored in a single local variable, which
+ * gives the compiler visibility to all changes to the register (and enables
+ * optimization / simplification). Because there is just a single local variable,
+ * the Merge() function does not need to do anything (the value is accessible from
+ * the same location at all locations). The Commit() and Reload() functions simply
+ * move the value back and forth between the local variable and the structure that
+ * holds the actual virtual machine state.
+ */
+
+class VirtualMachineRegisterInStruct : public VirtualMachineRegister {
+public:
+    static StateKind STATEKIND;
+
+    /**
+     * @brief public constructor used to create a virtual machine state variable from struct
+     * @param vme VMExtension object to use
+     * @param name the name of the register
+     * @param func the function being compiled
+     * @param fieldType type of the field that holds the virtual machine state variable
+     * @param localHoldingStructAddress is the local variable symbol that holds the struct base address; it must have been stored in this symbol before control will reach the builder "b"
+     * @param doReload do a Reload on every entry builder for _func (defaults true, MakeCopy passes false)
+     */
+    VirtualMachineRegisterInStruct(LOCATION, VMExtension *vme, std::string name, Base::Function *func, const Base::FieldType *fieldType, Base::LocalSymbol * localHoldingStructAddress, bool doReload=true);
+
+    virtual void Commit(LOCATION, Builder * b);
+    virtual VirtualMachineState * MakeCopy(LOCATION, Builder *b);
+    // reuses MergeInto() from VirtualMachineRegister
+    virtual void Reload(LOCATION, Builder * b);
+
+    protected:
+    const Base::FieldType * _fieldType;
+    Base::LocalSymbol * _localHoldingStructAddress;
+};
+
+} // namespace VM
+} // namespace JitBuilder
+} // namespace OMR
+
+#endif // VIRTUALMACHINEREGISTERINSTRUCT_INCL

--- a/VM/VirtualMachineState.cpp
+++ b/VM/VirtualMachineState.cpp
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "vm/VirtualMachineState.hpp"
+#include "Builder.hpp"
+
+namespace OMR {
+namespace JitBuilder {
+namespace VM {
+
+VirtualMachineStateID VirtualMachineState::nextVirtualMachineStateID = NoVirtualMachineStateID+1;
+StateKind VirtualMachineState::STATEKIND = NoStateKind;
+std::map<std::string,StateKind> VirtualMachineState::stateKindFromNameMap;
+std::map<StateKind,std::string> VirtualMachineState::stateNameFromKindMap;
+
+VirtualMachineState *
+VirtualMachineState::MakeCopy(LOCATION, Builder *b) {
+    return new VirtualMachineState(PASSLOC, _vme, STATEKIND);
+}
+
+static StateKind
+getNextStateKind(StateKind k) {
+    if (k == NoStateKind) // 0 cannot be shifted
+        return AnyStateKind;
+    StateKind nextKind = k << 1;
+    return nextKind;
+}
+
+StateKind VirtualMachineState::nextStateKind=getNextStateKind(AnyStateKind);
+
+StateKind
+VirtualMachineState::assignStateKind(StateKind baseKind, std::string name) {
+    auto found = stateKindFromNameMap.find(name);
+    if (found != stateKindFromNameMap.end())
+        return found->second;
+            
+    StateKind kind = nextStateKind;
+    assert(kind != 0); // will eventually need a bit vector
+    nextStateKind = getNextStateKind(nextStateKind);
+
+    assert((baseKind & kind) == 0);
+    StateKind fullKind = baseKind | kind;
+    stateKindFromNameMap.insert({name, fullKind});
+    stateNameFromKindMap.insert({fullKind, name});
+    return fullKind;
+}
+
+} // namespace VM
+} // namespace JitBuilder
+} // namespace OMR

--- a/VM/VirtualMachineState.hpp
+++ b/VM/VirtualMachineState.hpp
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+        
+#ifndef VIRTUALMACHINESTATE_INCL
+#define VIRTUALMACHINESTATE_INCL
+
+#include "stdint.h"
+#include "stddef.h"
+#include <map>
+#include "CreateLoc.hpp"
+
+namespace OMR {
+namespace JitBuilder {
+
+class Builder;
+
+namespace VM {
+
+class BytecodeBuilder;
+class VMExtension;
+
+typedef uint64_t VirtualMachineStateID;
+const VirtualMachineStateID NoVirtualMachineStateID=0;
+
+typedef uint64_t StateKind;
+const StateKind NoStateKind=0;
+const StateKind AnyStateKind=1;
+
+class VirtualMachineState {
+public:
+    static StateKind STATEKIND;
+    VirtualMachineState(LOCATION, VMExtension *vme, StateKind kind)
+        : _id(nextVirtualMachineStateID++)
+        , _createLocation(PASSLOC)
+        , _vme(vme)
+        , _kind(kind) {
+
+    }
+
+    VirtualMachineStateID id() const { return _id; }
+    CreateLocation createLocation() const { return _createLocation; }
+    VMExtension *vme() const { return _vme; }
+
+    virtual void Commit(LOCATION, Builder * b) { }
+    virtual VirtualMachineState * MakeCopy(LOCATION, Builder *b);
+    virtual void MergeInto(LOCATION, VirtualMachineState * vmState, Builder * b) { }
+    virtual void Reload(LOCATION, Builder * b) { }
+
+    template<typename T> bool isKind() const {
+        return (_kind & T::STATEKIND) != 0;
+    }
+    template<typename T> const T *refine() const {
+        assert(isKind<T>());
+        return static_cast<const T *>(this);
+    }
+    template<typename T> T *refine() {
+        assert(isKind<T>());
+        return static_cast<T *>(this);
+    }
+
+    static StateKind assignStateKind(StateKind baseKind, std::string name);
+
+protected:
+    VirtualMachineStateID _id;
+    CreateLocation _createLocation;
+    VMExtension *_vme;
+    StateKind _kind;
+
+    static VirtualMachineStateID nextVirtualMachineStateID;
+    static StateKind nextStateKind;
+    static std::map<std::string,StateKind> stateKindFromNameMap;
+    static std::map<StateKind,std::string> stateNameFromKindMap;
+};
+
+} // namespace VM
+} // namespace JitBuilder
+} // namespace OMR
+
+#endif // !defined(VIRTUALMACHINESTATE_INCL)

--- a/VM/test/Makefile
+++ b/VM/test/Makefile
@@ -1,0 +1,37 @@
+COREDIR=../..
+CORE=jbcore
+LIBCORE=lib$(CORE).so
+
+BASEDIR=../../Base
+BASE=base
+LIBBASE=lib$(BASE).so
+
+VMDIR=../../VM
+VM=vm
+LIBVM=lib$(VM).so
+
+all: vmregister operandstacktest
+
+vmregister: VMRegister.o $(LIBCORE) $(LIBBASE) $(LIBVM)
+	g++ -FPIC -o vmregister VMRegister.o -L$(VMDIR) -l$(VM) -L$(BASEDIR) -l$(BASE) -L$(COREDIR) -l$(CORE) -ldl
+
+operandstacktest: OperandStackTests.o $(LIBCORE) $(LIBBASE) $(LIBVM)
+	g++ -FPIC -o operandstacktest OperandStackTests.o -L$(VMDIR) -l$(VM) -L$(BASEDIR) -l$(BASE) -L$(COREDIR) -l$(CORE) -ldl
+
+$(LIBVM): $(VMDIR)/$(LIBVM)
+	cp $(VMDIR)/$(LIBVM) $(LIBVM)
+
+$(LIBBASE): $(BASEDIR)/$(LIBBASE)
+	cp $(BASEDIR)/$(LIBBASE) $(LIBBASE)
+
+$(LIBCORE): $(COREDIR)/$(LIBCORE)
+	cp $(COREDIR)/$(LIBCORE) $(LIBCORE)
+
+#CXXFLAGS=-O2 -I./ -I../ -std=c++0x -fno-rtti -fPIC -Wno-writable-strings -D_XOPEN_SOURCE=0
+CXXFLAGS=-O0 -g -I../../ -I./ -std=c++0x -fno-rtti -fPIC -Wno-writable-strings -D_XOPEN_SOURCE=0
+
+.cpp.o:
+	g++ $(CXXFLAGS) -c $<
+
+clean:
+	rm -f $(LIBVM) $(LIBBASE) $(LIBCORE) vmregister *.o

--- a/VM/test/OperandStackTests.cpp
+++ b/VM/test/OperandStackTests.cpp
@@ -1,0 +1,633 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+
+#include <cstddef>
+#include <cstring>
+#include <dlfcn.h>
+#include <errno.h>
+#include <iostream>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "JBCore.hpp"
+#include "Base/Base.hpp"
+#include "VM/VM.hpp"
+#include "OperandStackTests.hpp"
+
+using std::cout;
+using std::cerr;
+
+using namespace OMR::JitBuilder;
+
+typedef struct Thread
+   {
+   int pad;
+   STACKVALUECTYPE *sp;
+   } Thread;
+
+class TestState : public VM::VirtualMachineState {
+public:
+    static VM::StateKind STATEKIND;
+
+    TestState(LOCATION, VM::VMExtension *vme)
+        : VM::VirtualMachineState(PASSLOC, vme, STATEKIND),
+        _stack(NULL),
+        _stackTop(NULL) {
+
+    }
+
+    TestState(LOCATION, VM::VMExtension *vme, VM::VirtualMachineOperandStack *stack, VM::VirtualMachineRegister *stackTop)
+        : VM::VirtualMachineState(PASSLOC, vme, STATEKIND),
+        _stack(stack),
+        _stackTop(stackTop) {
+
+    }
+
+    virtual void Commit(LOCATION, Builder *b) {
+        _stack->Commit(PASSLOC, b);
+        _stackTop->Commit(PASSLOC, b);
+    }
+
+    virtual void Reload(LOCATION, Builder *b) {
+        _stack->Reload(PASSLOC, b);
+        _stackTop->Reload(PASSLOC, b);
+    }
+
+    virtual VM::VirtualMachineState *MakeCopy(LOCATION, Builder *b) {
+        TestState *newState = new TestState(PASSLOC, _vme);
+        newState->_stack = _stack->MakeCopy(PASSLOC, b)->refine<VM::VirtualMachineOperandStack>();
+        newState->_stackTop = _stackTop->MakeCopy(PASSLOC, b)->refine<VM::VirtualMachineRegister>();
+        return newState;
+    }
+
+    virtual void MergeInto(LOCATION, VM::VirtualMachineState *other, Builder *b) {
+        TestState *otherState = other->refine<TestState>();
+        _stack->MergeInto(PASSLOC, otherState->_stack, b);
+        _stackTop->MergeInto(PASSLOC, otherState->_stackTop, b);
+    }
+
+    VM::VirtualMachineOperandStack * _stack;
+    VM::VirtualMachineRegister * _stackTop;
+};
+
+VM::StateKind TestState::STATEKIND = VirtualMachineState::assignStateKind(VirtualMachineState::STATEKIND, "TestState");
+
+static bool verbose = false;
+static int32_t numFailingTests = 0;
+static int32_t numPassingTests = 0;
+static STACKVALUECTYPE **verifySP = NULL;
+static STACKVALUECTYPE expectedResult12Top = -1;
+static char * result12Operator;
+static Thread thread;
+static bool useThreadSP = false;
+
+static void
+setupResult12Equals() {
+    expectedResult12Top = 11;
+    result12Operator = (char *)"==";
+}
+
+static void
+setupResult12NotEquals() {
+    expectedResult12Top = 99;
+    result12Operator = (char *)"!=";
+}
+
+int
+main(int argc, char *argv[]) {
+    if (argc == 2 && strcmp(argv[1], "--verbose") == 0)
+        verbose = true;
+
+    if (verbose) cout << "Step 0: load jbcore.so\n";
+    void *handle = dlopen("libjbcore.so", RTLD_LAZY);
+    if (!handle) {
+        fputs(dlerror(), stderr);
+        return -1;
+    }
+
+    if (verbose) cout << "Step 1: Create a Compiler\n";
+    Compiler compiler("OperandStackTests");
+
+    if (verbose) cout << "Step 2: load extensions (Base and VM)\n";
+    Base::BaseExtension *base = compiler.loadExtension<Base::BaseExtension>();
+    assert(base);
+    VM::VMExtension *vme = compiler.loadExtension<VM::VMExtension>();
+    assert(vme);
+
+    if (verbose) cout << "Step 3: Create Function object\n";
+    OperandStackTestFunction pointerFunction(base, vme);
+
+    if (verbose) cout << "Step 4: Set up logging configuration\n";
+    Base::FunctionCompilation *comp = pointerFunction.comp();
+    TextWriter logger(comp, std::cout, std::string("    "));
+    TextWriter *log = (verbose) ? &logger : NULL;
+    
+    if (verbose) cout << "Step 5: compile function\n";
+    CompilerReturnCode result = pointerFunction.Compile(log);
+    
+    if (result != compiler.CompileSuccessful) {
+        cout << "Compile failed: " << result << "\n";
+        exit(-1);
+    }
+
+    if (verbose) cout << "Step 6: invoke compiled function and print results\n";
+    typedef void (OperandStackTestProto)();
+    OperandStackTestProto *ptrTest = pointerFunction.nativeEntry<OperandStackTestProto *>();
+    verifySP = pointerFunction.getSPPtr();
+    setupResult12Equals();
+    ptrTest();
+
+    if (verbose) cout << "Step 7: Set up operand stack tests using a Thread structure\n";
+    OperandStackTestUsingStructFunction threadFunction(base, vme);
+    comp = threadFunction.comp();
+    TextWriter logger2(comp, std::cout, std::string("    "));
+    TextWriter *log2 = (verbose) ? &logger : NULL;
+
+    if (verbose) cout << "Step 8: compile function\n";
+    result = threadFunction.Compile(log2);
+    if (result != compiler.CompileSuccessful) {
+        cout << "Compile failed: " << result << "\n";
+        exit(-1);
+    }
+
+    if (verbose) cout << "Step 9: invoke compiled code and print results\n";
+    typedef void (OperandStackTestUsingStructProto)(Thread *thread);
+    OperandStackTestUsingStructProto *threadTest = threadFunction.nativeEntry<OperandStackTestUsingStructProto *>();
+
+    useThreadSP = true;
+    verifySP = &thread.sp;
+    setupResult12NotEquals();
+    threadTest(&thread);
+
+    cout << "Number passing tests: " << numPassingTests << "\n";
+    cout << "Number failing tests: " << numFailingTests << "\n";
+
+    if (numFailingTests == 0)
+        cout << "ALL PASS\n";
+    else
+        cout << "SOME FAILURES\n";
+}
+
+
+STACKVALUECTYPE *OperandStackTestFunction::_realStack = NULL;
+STACKVALUECTYPE *OperandStackTestFunction::_realStackTop = _realStack - 1;
+int32_t OperandStackTestFunction::_realStackSize = -1;
+
+void
+OperandStackTestFunction::createStack() {
+    int32_t stackSizeInBytes = _realStackSize * sizeof(STACKVALUECTYPE);
+    _realStack = (STACKVALUECTYPE *) malloc(stackSizeInBytes);
+    _realStackTop = _realStack - 1;
+    thread.sp = _realStackTop;
+    memset(_realStack, 0, stackSizeInBytes);
+}
+
+STACKVALUECTYPE *
+OperandStackTestFunction::moveStack() {
+    int32_t stackSizeInBytes = _realStackSize * sizeof(STACKVALUECTYPE);
+    STACKVALUECTYPE *newStack = (STACKVALUECTYPE *) malloc(stackSizeInBytes);
+    int32_t delta = 0;
+    if (useThreadSP)
+        delta = thread.sp - _realStack;
+    else
+        delta = _realStackTop - _realStack;
+    memcpy(newStack, _realStack, stackSizeInBytes);
+    memset(_realStack, 0xFF, stackSizeInBytes);
+    free(_realStack);
+    _realStack = newStack;
+    _realStackTop = _realStack + delta;
+    thread.sp = _realStackTop;
+
+    return _realStack - 1;
+}
+
+void
+OperandStackTestFunction::freeStack() {
+    memset(_realStack, 0xFF, _realStackSize * sizeof(STACKVALUECTYPE));
+    free(_realStack);
+    _realStack = NULL;
+    _realStackTop = NULL;
+    thread.sp = NULL;
+}
+
+static void FailingTest() {
+    numFailingTests++;
+}
+
+static void PassingTest() {
+    numPassingTests++;
+}
+
+#define REPORT1(c,n,v)         { if (c) { PassingTest(); if (verbose) cout << "Pass\n"; } else { FailingTest(); if (verbose) cout << "Fail: " << (n) << " is " << (v) << "\n"; } }
+#define REPORT2(c,n1,v1,n2,v2) { if (c) { PassingTest(); if (verbose) cout << "Pass\n"; } else { FailingTest(); if (verbose) cout << "Fail: " << (n1) << " is " << (v1) << ", " << (n2) << " is " << (v2) << "\n"; } }
+
+// Result 0: empty stack even though Push has happened
+void
+verifyResult0() {
+    if (verbose) cout << "Push(1)  [ no commit ]\n";
+    OperandStackTestFunction::verifyStack("0", -1, 0);
+}
+
+void
+verifyResult1() {
+    if (verbose) cout << "Commit(); Top()\n";
+    OperandStackTestFunction::verifyStack("1", 0, 1, 1);
+}
+
+void
+verifyResult2(STACKVALUECTYPE top) {
+    if (verbose) cout << "Push(2); Push(3); Top()   [ no commit]\n";
+    if (verbose) cout << "\tResult 2: top value == 3: ";
+    REPORT1(top == 3, "top", top);
+
+    OperandStackTestFunction::verifyStack("2", 0, 1, 1);
+}
+
+void
+verifyResult3(STACKVALUECTYPE top) {
+    if (verbose) cout << "Commit(); Top()\n";
+    if (verbose) cout << "\tResult 3: top value == 3: ";
+    REPORT1(top == 3, "top", top);
+
+    OperandStackTestFunction::verifyStack("3", 2, 3, 1, 2, 3);
+}
+
+void
+verifyResult4(STACKVALUECTYPE popValue) {
+    if (verbose) cout << "Pop()    [ no commit]\n";
+    if (verbose) cout << "\tResult 4: pop value == 3: ";
+    REPORT1(popValue == 3, "popValue", popValue);
+
+    OperandStackTestFunction::verifyStack("4", 2, 3, 1, 2, 3);
+}
+
+void
+verifyResult5(STACKVALUECTYPE popValue) {
+    if (verbose) cout << "Pop()    [ no commit]\n";
+    if (verbose) cout << "\tResult 5: pop value == 2: ";
+    REPORT1(popValue == 2, "popValue", popValue);
+
+    OperandStackTestFunction::verifyStack("5", 2, 3, 1, 2, 3);
+}
+
+void
+verifyResult6(STACKVALUECTYPE top) {
+    if (verbose) cout << "Push(Add(popValue1, popValue2)); Commit(); Top()\n";
+    if (verbose) cout << "\tResult 6: top == 5: ";
+    REPORT1(top == 5, "top", top);
+
+    OperandStackTestFunction::verifyStack("6", 2, 2, 1, 5);
+}
+
+void
+verifyResult7() {
+    if (verbose) cout << "Drop(2); Commit(); [ empty stack ]\n";
+    OperandStackTestFunction::verifyStack("7", 2, 0);
+}
+
+void
+verifyResult8(STACKVALUECTYPE pick) {
+    if (verbose) cout << "Push(5); Push(4); Push(3); Push(2); Push(1); Commit(); Pick(3)\n";
+    if (verbose) cout << "\tResult 8: pick == 4: ";
+    REPORT1(pick == 4, "pick", pick);
+
+    OperandStackTestFunction::verifyStack("8", 2, 0);
+}
+
+void
+verifyResult9(STACKVALUECTYPE top) {
+    if (verbose) cout << "Drop(2); Top()\n";
+    if (verbose) cout << "\tResult 9: top == 3: ";
+    REPORT1(top == 3, "top", top);
+
+    OperandStackTestFunction::verifyStack("9", 2, 0);
+}
+
+void
+verifyResult10(STACKVALUECTYPE pick) {
+    if (verbose) cout << "Dup(); Pick(2)\n";
+    if (verbose) cout << "\tResult 10: pick == 4: ";
+    REPORT1(pick == 4, "pick", pick);
+ 
+    OperandStackTestFunction::verifyStack("10", 2, 0);
+}
+
+void
+verifyResult11() {
+    if (verbose) cout << "Commit();\n";
+    OperandStackTestFunction::verifyStack("11", 3, 4, 5, 4, 3, 3);
+}
+
+void
+verifyResult12(STACKVALUECTYPE top) {
+    if (verbose) cout << "Pop(); Pop(); if (3 " << result12Operator << " 3) { Push(11); } else { Push(99); } Commit(); Top();\n";
+    if (verbose) cout << "\tResult 12: top == " << expectedResult12Top << ": ";
+    REPORT1(top == expectedResult12Top, "top", top);
+    OperandStackTestFunction::verifyStack("11", 3, 3, 5, 4, expectedResult12Top);
+}
+
+// used to compare expected values and report fail it not equal
+void
+verifyValuesEqual(STACKVALUECTYPE v1, STACKVALUECTYPE v2) { 
+    REPORT2(v1 == v2, "verifyValuesEqual v1", v1, "verifyValuesEqual v2", v2); 
+}
+
+// take the arguments from the stack and modify them
+void
+modifyTop3Elements(int32_t amountToAdd) {
+    if (verbose) cout << "Push();Push();Push() - modify elements passed in real stack and return";
+    STACKVALUECTYPE *realSP = *verifySP; 
+    REPORT1(realSP[0]== 3, "modifyTop3Elements realSP[0]", realSP[0]); 
+    REPORT1(realSP[-1]== 2, "modifyTop3Elements realSP[-1]", realSP[-1]); 
+    REPORT1(realSP[-2]== 1, "modifyTop3Elements realSP[-2]", realSP[-2]); 
+    realSP[0] += amountToAdd;
+    realSP[-1] += amountToAdd;
+    realSP[-2] += amountToAdd;  
+}
+
+
+
+
+bool
+OperandStackTestFunction::verifyUntouched(int32_t maxTouched) {
+    for (int32_t i=maxTouched+1;i < _realStackSize;i++) 
+        if (_realStack[i] != 0)
+            return false;
+    return true;
+}
+
+void
+OperandStackTestFunction::verifyStack(const char *step, int32_t max, int32_t num, ...) {
+
+    STACKVALUECTYPE *realSP = *verifySP;
+
+    if (verbose) cout << "\tResult " << step << ": realSP-_realStack == " << (num-1) << ": ";
+    REPORT2((realSP-_realStack) == (num-1), "_realStackTop-_realStack", (realSP-_realStack), "num-1", (num-1));
+
+    va_list args;
+    va_start(args, num);
+    for (int32_t a=0;a < num;a++) {
+        STACKVALUECTYPE val = va_arg(args, STACKVALUECTYPE);
+        if (verbose) cout << "\tResult " << step << ": _realStack[" << a << "] == " << val << ": ";
+        REPORT2(_realStack[a] == val, "_realStack[a]", _realStack[a], "val", val);
+    }
+    va_end(args);
+
+    if (verbose) cout << "\tResult " << step << ": upper stack untouched: ";
+    REPORT1(verifyUntouched(max), "max", max);
+}
+
+
+OperandStackTestFunction::OperandStackTestFunction(Base::BaseExtension *base, VM::VMExtension *vme)
+    : Base::Function(base->compiler())
+    , _base(base)
+    , _vme(vme) {
+
+    DefineLine(LINETOSTR(__LINE__));
+    DefineFile(__FILE__);
+
+    DefineName("OperandStackTest");
+    const Type *NoType = base->NoType;
+    DefineReturnType(NoType);
+
+    _realStackSize = 32;
+    _valueType = base->STACKVALUETYPE;
+    const Type *pValueType = _base->PointerTo(LOC, comp(), _valueType);
+
+    _createStack = DefineFunction(LOC, "createStack", "0", "0", (void *)&OperandStackTestFunction::createStack, NoType, 0);
+    _moveStack = DefineFunction(LOC, "moveStack", "0", "0", (void *)&OperandStackTestFunction::moveStack, pValueType, 0);
+    _freeStack = DefineFunction(LOC, "freeStack", "0", "0", (void *)&OperandStackTestFunction::freeStack, NoType, 0);
+    _verifyResult0 = DefineFunction(LOC, "verifyResult0", "0", "0", (void *)&verifyResult0, NoType, 0);
+    _verifyResult1 = DefineFunction(LOC, "verifyResult1", "0", "0", (void *)&verifyResult1, NoType, 0);
+    _verifyResult2 = DefineFunction(LOC, "verifyResult2", "0", "0", (void *)&verifyResult2, NoType, 1, _valueType);
+    _verifyResult3 = DefineFunction(LOC, "verifyResult3", "0", "0", (void *)&verifyResult3, NoType, 1, _valueType);
+    _verifyResult4 = DefineFunction(LOC, "verifyResult4", "0", "0", (void *)&verifyResult4, NoType, 1, _valueType);
+    _verifyResult5 = DefineFunction(LOC, "verifyResult5", "0", "0", (void *)&verifyResult5, NoType, 1, _valueType);
+    _verifyResult6 = DefineFunction(LOC, "verifyResult6", "0", "0", (void *)&verifyResult6, NoType, 1, _valueType);
+    _verifyResult7 = DefineFunction(LOC, "verifyResult7", "0", "0", (void *)&verifyResult7, NoType, 0);
+    _verifyResult8 = DefineFunction(LOC, "verifyResult8", "0", "0", (void *)&verifyResult8, NoType, 1, _valueType);
+    _verifyResult9 = DefineFunction(LOC, "verifyResult9", "0", "0", (void *)&verifyResult9, NoType, 1, _valueType);
+    _verifyResult10 = DefineFunction(LOC, "verifyResult10", "0", "0", (void *)&verifyResult10, NoType, 1, _valueType);
+    _verifyResult11 = DefineFunction(LOC, "verifyResult11", "0", "0", (void *)&verifyResult11, NoType, 0);
+    _verifyResult12 = DefineFunction(LOC, "verifyResult12", "0", "0", (void *)&verifyResult12, NoType, 1, _valueType);
+    _verifyValuesEqual = DefineFunction(LOC, "verifyValuesEqual", "0", "0", (void *)&verifyValuesEqual, NoType, 2, _valueType, _valueType);
+    _modifyTop3Elements = DefineFunction(LOC, "modifyTop3Elements", "0", "0", (void *)&modifyTop3Elements, NoType, 1, _valueType);
+}
+
+// convenience macros
+#define STACK(b)           (((b)->vmState()->refine<TestState>())->_stack)
+#define STACKTOP(b)        (((b)->vmState()->refine<TestState>())->_stackTop)
+#define COMMIT(b)          ((b)->vmState()->Commit(LOC, b))
+#define RELOAD(b)          ((b)->vmState()->Reload(LOC, b))
+#define UPDATESTACK(b,s)   (STACK(b)->UpdateStack(LOC, b, s))
+#define PUSH(b,v)          (STACK(b)->Push(v))
+#define POP(b)             (STACK(b)->Pop())
+#define TOP(b)             (STACK(b)->Top())
+#define DUP(b)             (STACK(b)->Dup())
+#define DROP(b,d)          (STACK(b)->Drop(d))
+#define PICK(b,d)          (STACK(b)->Pick(d))
+
+VM::BytecodeBuilder *
+OperandStackTestFunction::testStack(VM::BytecodeBuilder *b, bool useEqual) {
+    STACKVALUECTYPE one=1;
+    Literal *lv1 = _valueType->literal(LOC, comp(), reinterpret_cast<LiteralBytes *>(&one));
+    PUSH(b, _base->Const(LOC, b, lv1));
+    _base->Call(LOC, b, _verifyResult0);
+
+    COMMIT(b);
+    _base->Call(LOC, b, _verifyResult1);
+
+    STACKVALUECTYPE two=2;
+    Literal *lv2 = _valueType->literal(LOC, comp(), reinterpret_cast<LiteralBytes *>(&two));
+    PUSH(b, _base->Const(LOC, b, lv2));
+
+    STACKVALUECTYPE three=3;
+    Literal *lv3 = _valueType->literal(LOC, comp(), reinterpret_cast<LiteralBytes *>(&three));
+    PUSH(b, _base->Const(LOC, b, lv3));
+    _base->Call(LOC, b, _verifyResult2, TOP(b));
+
+    COMMIT(b);
+    Value *newStack = _base->Call(LOC, b, _moveStack);
+    UPDATESTACK(b, newStack);
+    _base->Call(LOC, b, _verifyResult3, TOP(b));
+
+    Value *val1 = POP(b);
+    _base->Call(LOC, b, _verifyResult4, val1);
+
+    Value *val2 = POP(b);
+    _base->Call(LOC, b, _verifyResult5, val2);
+
+    Value *sum = _base->Add(LOC, b, val1, val2);
+    PUSH(b, sum);
+    COMMIT(b);
+    newStack = _base->Call(LOC, b, _moveStack);
+    UPDATESTACK(b, newStack);
+    _base->Call(LOC, b, _verifyResult6, TOP(b));
+
+    DROP(b, 2);
+    COMMIT(b);
+    _base->Call(LOC, b, _verifyResult7);
+
+    STACKVALUECTYPE four=4;
+    Literal *lv4 = _valueType->literal(LOC, comp(), reinterpret_cast<LiteralBytes *>(&four));
+    STACKVALUECTYPE five=5;
+    Literal *lv5 = _valueType->literal(LOC, comp(), reinterpret_cast<LiteralBytes *>(&five));
+
+    PUSH(b, _base->Const(LOC, b, lv5));
+    PUSH(b, _base->Const(LOC, b, lv4));
+    PUSH(b, _base->Const(LOC, b, lv3));
+    PUSH(b, _base->Const(LOC, b, lv2));
+    PUSH(b, _base->Const(LOC, b, lv1));
+    _base->Call(LOC, b, _verifyResult8, PICK(b, 3));
+
+    DROP(b, 2);
+    _base->Call(LOC, b, _verifyResult9, TOP(b));
+
+    DUP(b);
+    _base->Call(LOC, b, _verifyResult10, PICK(b, 2));
+
+    COMMIT(b);
+    newStack = _base->Call(LOC, b, _moveStack);
+    UPDATESTACK(b, newStack);
+    _base->Call(LOC, b, _verifyResult11);
+
+    VM::BytecodeBuilder *thenBB = _vme->OrphanBytecodeBuilder(comp(), 1, 1, "BCI_then");
+    VM::BytecodeBuilder *elseBB = _vme->OrphanBytecodeBuilder(comp(), 2, 1, "BCI_else");
+    VM::BytecodeBuilder *mergeBB = _vme->OrphanBytecodeBuilder(comp(), 3, 1, "BCI_merge");
+
+    Value *v1 = POP(b);
+    Value *v2 = POP(b);
+    if (useEqual)
+        _vme->IfCmpEqual(LOC, b, thenBB, v1, v2);
+    else
+        _vme->IfCmpNotEqual(LOC, b, thenBB, v1, v2);
+    _vme->Goto(LOC, b, elseBB);
+
+    STACKVALUECTYPE eleven=11;
+    Literal *lv11 = _valueType->literal(LOC, comp(), reinterpret_cast<LiteralBytes *>(&eleven));
+    PUSH(thenBB, _base->Const(LOC, thenBB, lv11));
+    _vme->Goto(LOC, thenBB, mergeBB);
+
+    STACKVALUECTYPE ninetynine=99;
+    Literal *lv99 = _valueType->literal(LOC, comp(), reinterpret_cast<LiteralBytes *>(&ninetynine));
+    PUSH(elseBB, _base->Const(LOC, elseBB, lv99));
+    _vme->Goto(LOC, elseBB, mergeBB);
+
+    COMMIT(mergeBB);
+    newStack = _base->Call(LOC, mergeBB, _moveStack);
+    UPDATESTACK(mergeBB, newStack);
+    _base->Call(LOC, mergeBB, _verifyResult12, TOP(mergeBB));
+ 
+    STACKVALUECTYPE amountToAdd = 10;
+    Literal *lvAmount = _valueType->literal(LOC, comp(), reinterpret_cast<LiteralBytes *>(&amountToAdd));
+
+    // Reload test. Call a routine that modifies stack elements passed to it. 
+    // Test by reloading and test the popped values
+    PUSH(mergeBB, _base->Const(LOC, mergeBB, lv1));
+    PUSH(mergeBB, _base->Const(LOC, mergeBB, lv2));
+    PUSH(mergeBB, _base->Const(LOC, mergeBB, lv3));  
+    COMMIT(mergeBB); 
+    _base->Call(LOC, mergeBB, _modifyTop3Elements, _base->Const(LOC, mergeBB, lvAmount));  
+    RELOAD(mergeBB);
+
+    Value *modifiedStackElement = POP(mergeBB);
+    STACKVALUECTYPE amountPlus3 = 3+amountToAdd;
+    Literal *lvAmountPlus3 = _valueType->literal(LOC, comp(), reinterpret_cast<LiteralBytes *>(&amountPlus3));
+    Value *expected =  _base->Const(LOC, mergeBB, lvAmountPlus3); 
+    _base->Call(LOC, mergeBB, _verifyValuesEqual, modifiedStackElement, expected);  
+
+    modifiedStackElement = POP(mergeBB);
+    STACKVALUECTYPE amountPlus2 = 2+amountToAdd;
+    Literal *lvAmountPlus2 = _valueType->literal(LOC, comp(), reinterpret_cast<LiteralBytes *>(&amountPlus2));
+    expected = _base->Const(LOC, mergeBB, lvAmountPlus2);
+    _base->Call(LOC, mergeBB, _verifyValuesEqual, modifiedStackElement, expected);  
+
+    modifiedStackElement = POP(mergeBB);
+    STACKVALUECTYPE amountPlus1 = 1+amountToAdd;
+    Literal *lvAmountPlus1 = _valueType->literal(LOC, comp(), reinterpret_cast<LiteralBytes *>(&amountPlus1));
+    expected =  _base->Const(LOC, mergeBB, lvAmountPlus1);
+    _base->Call(LOC, mergeBB, _verifyValuesEqual, modifiedStackElement, expected);  
+
+    _base->Call(LOC, mergeBB, _freeStack);
+
+    _base->Return(LOC, mergeBB);
+
+    return mergeBB;
+}
+
+bool
+OperandStackTestFunction::buildIL() {
+    const Base::PointerType *pElementType = _base->PointerTo(LOC, comp(), _base->PointerTo(LOC, comp(), _base->STACKVALUETYPE));
+
+    Builder *entry = builderEntry();
+    _base->Call(LOC, entry, _createStack);
+
+    Value *realStackTopAddress = _base->ConstPointer(LOC, entry, pElementType, &_realStackTop);
+    VM::VirtualMachineRegister *stackTop = new VM::VirtualMachineRegister(LOC, _vme, "SP", this, realStackTopAddress);
+    VM::VirtualMachineOperandStack *stack = new VM::VirtualMachineOperandStack(LOC, _vme, this, 1, stackTop, _base->STACKVALUETYPE);
+
+    TestState *vmState = new TestState(LOC, _vme, stack, stackTop);
+
+    VM::BytecodeBuilder *bb = _vme->OrphanBytecodeBuilder(comp(), 0, 1, std::string("entry"));
+    bb->setVMState(vmState);
+    _base->Goto(LOC, entry, bb);
+
+    testStack(bb, true);
+
+    return true;
+}
+
+
+
+
+OperandStackTestUsingStructFunction::OperandStackTestUsingStructFunction(Base::BaseExtension *base, VM::VMExtension *vme)
+    : OperandStackTestFunction(base, vme) {
+
+    Base::StructTypeBuilder builder(base, this);
+    builder.setName("Thread")
+           ->addField("sp", base->PointerTo(LOC, comp(), base->STACKVALUETYPE), 8*offsetof(Thread, sp));
+    _threadType = builder.create(LOC);
+    _spField = _threadType->LookupField("sp");
+
+    _threadParam = DefineParameter("thread", base->PointerTo(LOC, comp(), _threadType));
+}
+
+bool
+OperandStackTestUsingStructFunction::buildIL() {
+    Builder *entry = builderEntry();
+
+    _base->Call(LOC, entry, _createStack);
+
+    VM::VirtualMachineRegisterInStruct *stackTop = new VM::VirtualMachineRegisterInStruct(LOC, _vme, "SP", this, _spField, _threadParam);
+    VM::VirtualMachineOperandStack *stack = new VM::VirtualMachineOperandStack(LOC, _vme, this, 1, stackTop, _base->STACKVALUETYPE);
+
+    TestState *vmState = new TestState(LOC, _vme, stack, stackTop);
+    VM::BytecodeBuilder *bb = _vme->OrphanBytecodeBuilder(comp(), 0, 1, std::string("entry"));
+    bb->setVMState(vmState);
+    _base->Goto(LOC, entry, bb);
+
+    testStack(bb, false);
+
+    return true;
+}

--- a/VM/test/OperandStackTests.hpp
+++ b/VM/test/OperandStackTests.hpp
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+
+#ifndef OPERANDSTACKTESTS_INCL
+#define OPERANDSTACKTESTS_INCL
+
+#include <stddef.h>
+#include "Base/Function.hpp"
+
+#define STACKVALUETYPE	Int32
+#define STACKVALUECTYPE int32_t
+
+//#define STACKVALUETYPE  Base::Int64
+//#define STACKVALUECTYPE int64_t
+
+namespace OMR {
+    namespace JitBuilder {
+        class Compiler;
+
+        namespace Base {
+            class BytecodeBuilder;
+            class StructType;
+        }
+    }
+}
+
+using namespace OMR::JitBuilder;
+
+class OperandStackTestFunction : public Base::Function {
+public:
+    OperandStackTestFunction(Base::BaseExtension *base, VM::VMExtension *vme);
+    virtual bool buildIL();
+
+    static void verifyStack(const char *step, int32_t max, int32_t num, ...);
+    static bool verifyUntouched(int32_t maxTouched);
+
+    STACKVALUECTYPE **getSPPtr() { return &_realStackTop; }
+
+protected:
+    VM::BytecodeBuilder * testStack(VM::BytecodeBuilder *b, bool useEqual);
+
+    Base::BaseExtension *_base;
+    VM::VMExtension *_vme;
+
+    const Type * _valueType;
+
+    Base::FunctionSymbol *_createStack;
+    Base::FunctionSymbol *_moveStack;
+    Base::FunctionSymbol *_freeStack;
+    Base::FunctionSymbol *_verifyResult0;
+    Base::FunctionSymbol *_verifyResult1;
+    Base::FunctionSymbol *_verifyResult2;
+    Base::FunctionSymbol *_verifyResult3;
+    Base::FunctionSymbol *_verifyResult4;
+    Base::FunctionSymbol *_verifyResult5;
+    Base::FunctionSymbol *_verifyResult6;
+    Base::FunctionSymbol *_verifyResult7;
+    Base::FunctionSymbol *_verifyResult8;
+    Base::FunctionSymbol *_verifyResult9;
+    Base::FunctionSymbol *_verifyResult10;
+    Base::FunctionSymbol *_verifyResult11;
+    Base::FunctionSymbol *_verifyResult12;
+    Base::FunctionSymbol *_verifyValuesEqual;
+    Base::FunctionSymbol *_modifyTop3Elements;
+
+    static STACKVALUECTYPE * _realStack;
+    static STACKVALUECTYPE * _realStackTop;
+    static int32_t _realStackSize;
+
+    static void createStack();
+    static STACKVALUECTYPE *moveStack();
+    static void freeStack();
+};
+
+class OperandStackTestUsingStructFunction : public OperandStackTestFunction {
+public:
+    OperandStackTestUsingStructFunction(Base::BaseExtension *base, VM::VMExtension *vme);
+    virtual bool buildIL();
+
+protected:
+    const Base::StructType *_threadType;
+    const Base::FieldType *_spField;
+    Base::ParameterSymbol *_threadParam;
+};
+
+#endif // !defined(OPERANDSTACKTESTS_INCL)

--- a/VM/test/VMRegister.cpp
+++ b/VM/test/VMRegister.cpp
@@ -1,0 +1,205 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+
+#include <dlfcn.h>
+#include <iostream>
+#include <stdlib.h>
+#include <stdint.h>
+#include <errno.h>
+
+#include "JBCore.hpp"
+#include "Base/Base.hpp"
+#include "VM/VM.hpp"
+#include "VMRegister.hpp"
+
+using std::cout;
+using std::cerr;
+
+#define TOSTR(x)     #x
+#define LINETOSTR(x) TOSTR(x)
+
+#define DO_LOGGING true
+
+int
+main(int argc, char *argv[]) {
+    cout << "Step 0: load jbcore.so\n";
+    void *handle = dlopen("libjbcore.so", RTLD_LAZY);
+    if (!handle) {
+        fputs(dlerror(), stderr);
+        return -1;
+    }
+
+    cout << "Step 1: create a Compiler\n";
+    Compiler c("VirtualMachineRegisterTest");
+
+    cout << "Step 2: load extensions (Base and VM)\n";
+    Base::BaseExtension *base = c.loadExtension<Base::BaseExtension>();
+    assert(base);
+    VM::VMExtension *vme = c.loadExtension<VM::VMExtension>();
+    assert(vme);
+
+    cout << "Step 3: Create Function object\n";
+    VMRegisterFunction vmrFunc(&c);
+
+    cout << "Step 4: Set up logging configuration\n";
+    Base::FunctionCompilation *comp = vmrFunc.comp();
+    TextWriter logger(comp, std::cout, std::string("    "));
+    TextWriter *log = (DO_LOGGING) ? &logger : NULL;
+    
+    cout << "Step 5: compile vmregister function\n";
+    CompilerReturnCode result = vmrFunc.Compile(log);
+
+    if (result != c.CompileSuccessful) {
+        cout << "Compile failed: " << result << "\n";
+        exit(-1);
+    }
+    
+    cout << "Step 6: invoke compiled vmregister function and print results\n";
+    typedef int32_t (VMRegisterMethodFunction)(int8_t **values, int32_t count);
+    VMRegisterMethodFunction *vmregister = vmrFunc.nativeEntry<VMRegisterMethodFunction *>();
+
+    int8_t values[] = {7,2,9,5,3,1,6};
+    int8_t *vals = values;
+    int32_t retVal = vmregister(&vals, 7);
+    cout << "vmregister(values) returned " << retVal << "\n";
+
+    cout << "Step 7: compile vmregisterInStruct function\n";
+    VMRegisterInStructFunction vmrisFunc(&c);
+    result = vmrisFunc.Compile(log); 
+
+    if (result != c.CompileSuccessful) {
+        cout << "Compile failed: " << result << "\n";
+        exit(-2);
+    }
+    
+    cout << "Step 8: invoke compiled vmregisterInStruct function and print results\n";
+    typedef int32_t (VMRegisterInStructFunction)(VMRegisterStruct *param);
+    VMRegisterInStructFunction *vmregisterInStruct = vmrisFunc.nativeEntry<VMRegisterInStructFunction *>();
+
+    VMRegisterStruct param;
+    param.count = 7;
+    param.values = values;
+    retVal = vmregisterInStruct(&param);
+    cout << "vmregisterInStruct(values) returned " << retVal << "\n";
+
+    retVal=0;
+    for (int32_t i=0;i < 7;i++)
+        retVal += values[i];
+    cout << "Correct return value should be " << retVal << " in both cases\n";
+
+    cout << "Step 9: allow Compiler object to die (shuts down JIT because it's the last Compiler)\n";
+}
+
+
+VMRegisterFunction::VMRegisterFunction(Compiler *compiler)
+    : Base::Function(compiler)
+    , _base(compiler->lookupExtension<Base::BaseExtension>())
+    , _vme(compiler->lookupExtension<VM::VMExtension>()) {
+
+    DefineLine(LINETOSTR(__LINE__));
+    DefineFile(__FILE__);
+
+    DefineName("vmregister");
+    _values = DefineParameter("valuesPtr", _base->PointerTo(LOC, comp(), _base->PointerTo(LOC, comp(), _base->Int8)));
+    _count = DefineParameter("count", _base->Int32);
+    DefineReturnType(_base->Int32);
+}
+
+bool
+VMRegisterFunction::buildIL() {
+    Builder *entry = builderEntry();
+    VM::VirtualMachineRegister *vmreg = new VM::VirtualMachineRegister(LOC, _vme, "MYBYTES", this, _base->Load(LOC, entry, _values));
+
+    Base::LocalSymbol *result = DefineLocal("result", _base->Int32);
+    _base->Store(LOC, entry, result, _base->ConstInt32(LOC, entry, 0));
+
+    Base::LocalSymbol *iterVar = DefineLocal("i", _base->Int32);
+    Base::ForLoopBuilder *loop = _base->ForLoopUp(LOC, entry, iterVar, 
+                                                  _base->ConstInt32(LOC, entry, 0),
+                                                  _base->Load(LOC, entry, _count),
+                                                  _base->ConstInt32(LOC, entry, 1)); {
+
+        Builder *body = loop->loopBody();
+
+        Value *val = _base->LoadAt(LOC, body, vmreg->Load(LOC, body));
+
+        Value *bumpAmount = _base->ConvertTo(LOC, body, _base->Int32, val);
+        Value *newval = _base->Add(LOC, body, _base->Load(LOC, body, result), bumpAmount);
+        _base->Store(LOC, body, result, newval);
+        vmreg->Adjust(LOC, body, 1);
+    }
+
+    _base->Return(LOC, entry, _base->Load(LOC, entry, result));
+
+    return true;
+}
+
+
+VMRegisterInStructFunction::VMRegisterInStructFunction(Compiler *compiler)
+    : Base::Function(compiler)
+    , _base(compiler->lookupExtension<Base::BaseExtension>())
+    , _vme(compiler->lookupExtension<VM::VMExtension>()) {
+
+    DefineLine(LINETOSTR(__LINE__));
+    DefineFile(__FILE__);
+
+    DefineName("vmregisterInStruct");
+    Base::StructTypeBuilder builder(_base, this);
+    builder.setName("VMRegisterStruct")
+          ->addField("values", _base->PointerTo(LOC, comp(), _base->Int8), 8*offsetof(VMRegisterStruct, values))
+          ->addField("count", _base->Int32, 8*offsetof(VMRegisterStruct, count));
+    const Base::StructType *vmRegisterStruct = builder.create(LOC);
+    _valuesField = vmRegisterStruct->LookupField("values");
+    _countField = vmRegisterStruct->LookupField("count");
+    _param = DefineParameter("param", _base->PointerTo(LOC, comp(), vmRegisterStruct));
+    DefineReturnType(_base->Int32);
+}
+
+bool
+VMRegisterInStructFunction::buildIL() {
+    Builder *entry = builderEntry();
+    VM::VirtualMachineRegisterInStruct *vmreg = new VM::VirtualMachineRegisterInStruct(LOC, _vme, "VALUES", this, _valuesField, _param);
+
+    Base::LocalSymbol *result = DefineLocal("result", _base->Int32);
+    _base->Store(LOC, entry, result, _base->ConstInt32(LOC, entry, 0));
+
+    Base::LocalSymbol *iterVar = DefineLocal("i", _base->Int32);
+    Base::ForLoopBuilder *loop = _base->ForLoopUp(LOC, entry, iterVar, 
+                                                  _base->ConstInt32(LOC, entry, 0),
+                                                  _base->LoadFieldAt(LOC, entry, _countField, _base->Load(LOC, entry, _param)),
+                                                  _base->ConstInt32(LOC, entry, 1)); {
+
+        Builder *body = loop->loopBody();
+
+        Value *val = _base->LoadAt(LOC, body, vmreg->Load(LOC, body));
+
+        Value *bumpAmount = _base->ConvertTo(LOC, body, _base->Int32, val);
+        Value *newval = _base->Add(LOC, body, _base->Load(LOC, body, result), bumpAmount);
+        _base->Store(LOC, body, result, newval);
+        vmreg->Adjust(LOC, body, 1);
+    }
+
+    _base->Return(LOC, entry, _base->Load(LOC, entry, result));
+
+    return true;
+}

--- a/VM/test/VMRegister.hpp
+++ b/VM/test/VMRegister.hpp
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+
+#ifndef VMREGISTER_INCL
+#define VMREGISTER_INCL
+
+#include "Base/Function.hpp"
+
+namespace OMR {
+    namespace JitBuilder {
+
+        class Compiler;
+
+        namespace Base {
+            class BaseExtension;
+            class LocalSymbol;
+            class ParameterSymbol;
+        }
+
+        namespace VM {
+            class VMExtension;
+        }
+    }
+}
+
+using namespace OMR::JitBuilder;
+
+class VMRegisterFunction : public Base::Function {
+public:
+    VMRegisterFunction(Compiler *compiler);
+    virtual bool buildIL();
+
+protected:
+    Base::BaseExtension *_base;
+    VM::VMExtension *_vme;
+
+    Base::ParameterSymbol *_values;
+    Base::ParameterSymbol *_count;
+};
+
+typedef struct VMRegisterStruct {
+   int8_t *values;
+   int32_t count;
+} VMRegisterStruct;
+
+class VMRegisterInStructFunction : public Base::Function {
+public:
+    VMRegisterInStructFunction(Compiler *compiler);
+    virtual bool buildIL();
+
+    protected:
+    Base::BaseExtension *_base;
+    VM::VMExtension *_vme;
+    const Base::FieldType *_valuesField;
+    const Base::FieldType *_countField;
+    Base::ParameterSymbol *_param;
+};
+
+#endif // !defined(VMREGISTER_INCL)


### PR DESCRIPTION
Adds support for a VM extension with BytecodeBuilder, VirtualMachineState,
VirtualMachineRegister, VirtualMachineRegisterInStruct, and
VirtualMachineOperandStack. Tests are added for virtual machine registers
and for the operand stack, but these are just the code samples from
JitBuilder ported to use the VM extension and JitBuilder 2. These tests
should really be greatly expanded to become better unit tests.

Signed-off-by: mstoodle <mstoodle@ca.ibm.com>